### PR TITLE
feat: add the support for selecting "columns" in the "featured" widget

### DIFF
--- a/wowchemy/layouts/partials/widgets/featured.html
+++ b/wowchemy/layouts/partials/widgets/featured.html
@@ -48,11 +48,22 @@
   {{ $i18n = "more_pages" }}
 {{ end }}
 
-<div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $st.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
-    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+<div class="row {{if not $st.Title | or (eq $columns "1") }}justify-content-center{{end}}">
+  
+  {{ if $st.Title }}
+    {{ if eq $columns "1" }}
+      <div class="col-12 col-lg-8 section-heading text-center">
+        <h1>{{ with $st.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
+        {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+      </div>
+    {{else}}
+      <div class="col-12 col-lg-4 section-heading">
+        <h1>{{ with $st.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
+        {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
   </div>
+    {{end}}
+  {{ end }}
+  
   <div class="col-12 col-lg-8">
 
     {{ with $st.Content }}{{ . }}{{ end }}


### PR DESCRIPTION
### Purpose

Add the support for selecting "columns" in the "featured" widget.

[design]
  columns = "1"

### Documentation
The "page" widget has supported this feature, I made the changes according to the "page" widget.

https://github.com/wowchemy/wowchemy-hugo-modules/blob/86da39719ccd0cb1348f33c8c6c03fd0c3a93686/wowchemy/layouts/partials/widgets/pages.html#L74-L87
